### PR TITLE
Move getMeetings and createMeeting to groupRoutes

### DIFF
--- a/backend/routes/groupRoutes.js
+++ b/backend/routes/groupRoutes.js
@@ -32,10 +32,11 @@ router.route("/:groupID")
 router.route("/:groupID/students")
     .get(getStudentsFromGroup)
 
-// localhost:5678/api/group/messages/<groupID>
+// localhost:5678/api/group/<groupID>/messages
 router.route("/:groupID/messages")
     .get(getMessages)
 
+// localhost:5678/api/group/<groupID>/meetings
 router.route("/:groupID/meetings")
     .get(getMeetings)
     .put(createMeeting)
@@ -44,6 +45,7 @@ router.route("/:groupID/meetings")
 router.route("/join/:groupID")
     .put(joinGroup)
 
+// localhost:5678/api/group/leave/<groupID>
 router.route("/leave/:groupID")
     .put(leaveGroup)
 

--- a/backend/routes/groupRoutes.js
+++ b/backend/routes/groupRoutes.js
@@ -12,24 +12,33 @@ const {
     leaveGroup
 } = require("../controllers/groupController")
 
+const {
+    getMeetings,
+    createMeeting
+} = require("../controllers/meetingController")
+
 // localhost:5678/api/group/
 router.route("/")
     .get(getAllGroups)
     .post(createGroup)
     
-    // localhost:5678/api/group/<groupID>
-    router.route("/:groupID")
-    .get(getGroup)
-    .put(updateGroup)
-    .delete(deleteGroup)
+// localhost:5678/api/group/<groupID>
+router.route("/:groupID")
+.get(getGroup)
+.put(updateGroup)
+.delete(deleteGroup)
 
 // localhost:5678/api/group/<groupID>/students
 router.route("/:groupID/students")
     .get(getStudentsFromGroup)
 
 // localhost:5678/api/group/messages/<groupID>
-router.route("/messages/:groupID")
+router.route("/:groupID/messages")
     .get(getMessages)
+
+router.route("/:groupID/meetings")
+    .get(getMeetings)
+    .put(createMeeting)
 
 // localhost:5678/api/group/join/<groupID>
 router.route("/join/:groupID")

--- a/backend/routes/groupRoutes.js
+++ b/backend/routes/groupRoutes.js
@@ -24,9 +24,9 @@ router.route("/")
     
 // localhost:5678/api/group/<groupID>
 router.route("/:groupID")
-.get(getGroup)
-.put(updateGroup)
-.delete(deleteGroup)
+    .get(getGroup)
+    .put(updateGroup)
+    .delete(deleteGroup)
 
 // localhost:5678/api/group/<groupID>/students
 router.route("/:groupID/students")

--- a/backend/routes/meetingRoutes.js
+++ b/backend/routes/meetingRoutes.js
@@ -8,14 +8,14 @@ const {
     getAllMeetings
 } = require("../controllers/meetingController")
 
-// localhost:6789/api/meetings/
+// localhost:6789/api/meeting
 router.route("/")
     .get(getAllMeetings)
 
 // For creating a new meeting and getting all group meetings,
 // check the groupRoutes.js file (because the routes make more sense)
 
-// localhost:6789/api/meetings/<meetingID>
+// localhost:6789/api/meeting/<meetingID>
 router.route("/:meetingID")
     .get(getMeetings)
     .put(updateMeeting)

--- a/backend/routes/meetingRoutes.js
+++ b/backend/routes/meetingRoutes.js
@@ -12,10 +12,8 @@ const {
 router.route("/")
     .get(getAllMeetings)
 
-// localhost:6789/api/meetings/<groupID>
-router.route("/:groupID")
-    .get(getMeetings)
-    .post(createMeeting)
+// For creating a new meeting and getting all group meetings,
+// check the groupRoutes.js file (because the routes make more sense)
 
 // localhost:6789/api/meetings/<meetingID>
 router.route("/:meetingID")

--- a/backend/routes/meetingRoutes.js
+++ b/backend/routes/meetingRoutes.js
@@ -1,8 +1,7 @@
 const express = require("express")
 const router = express.Router()
 const {
-    createMeeting,
-    getMeetings,
+    getOneMeeting,
     updateMeeting,
     deleteMeeting,
     getAllMeetings
@@ -17,7 +16,7 @@ router.route("/")
 
 // localhost:6789/api/meeting/<meetingID>
 router.route("/:meetingID")
-    .get(getMeetings)
+    .get(getOneMeeting)
     .put(updateMeeting)
     .delete(deleteMeeting)
 


### PR DESCRIPTION
The `getMeetings` and `createMeeting` have been moved over to `groupRoutes` to make the final route more logical and natural.

Ex (To get all meetings from a group): `study-sphere.me:6789/api/group/<groupID>/meetings`

Ex (To get one specific meeting): `study-sphere.me:6789/api/meeting/<meetingID>`