### PR TITLE
[Feature] Group Search API

### DIFF
--- a/backend/controllers/groupController.js
+++ b/backend/controllers/groupController.js
@@ -137,7 +137,7 @@ const getGroup = asyncHandler(async (request, result) => {
 
 const searchGroups = asyncHandler(async (request, result) => {
     try {
-        const { name, courses, majors } = request.body
+        const { name, courses, majors, maxResults } = request.body
 
         console.debug(`\n\nSearching for groups with name: ${name}, courses: ${courses}, majors: ${majors}`)
 
@@ -145,8 +145,8 @@ const searchGroups = asyncHandler(async (request, result) => {
         const groups = await Group.find({
             name: { $regex: name, $options: 'i' },
             courses: { $in: courses },
-            majors: { $in: majors }
-        })
+            majors: { $in: majors },
+        }).limit(maxResults)
 
         console.debug(`Found ${groups.length} groups`)
 

--- a/backend/controllers/groupController.js
+++ b/backend/controllers/groupController.js
@@ -135,6 +135,33 @@ const getGroup = asyncHandler(async (request, result) => {
     }
 })
 
+const searchGroups = asyncHandler(async (request, result) => {
+    try {
+        const { name, courses, majors } = request.body
+
+        console.debug(`\n\nSearching for groups with name: ${name}, courses: ${courses}, majors: ${majors}`)
+
+        // search for groups with the given parameters
+        const groups = await Group.find({
+            name: { $regex: name, $options: 'i' },
+            courses: { $in: courses },
+            majors: { $in: majors }
+        })
+
+        console.debug(`Found ${groups.length} groups`)
+
+        // return different result if nothing found
+        if (groups.length == 0) {
+            return result.status(404).json({ error: "No groups found" })
+        }
+
+        return result.status(200).json(groups)
+    } catch (e) {
+        console.error(e)
+        return result.status(500).json({ error: e })
+    }
+})
+
 const updateGroup = asyncHandler(async (request, result) => {
     try {
         const groupID = request.params.groupID
@@ -452,6 +479,7 @@ module.exports = {
     createGroup,
     getAllGroups,
     getGroup,
+    searchGroups,
     updateGroup,
     deleteGroup,
     joinGroup,

--- a/backend/controllers/groupController.js
+++ b/backend/controllers/groupController.js
@@ -137,13 +137,14 @@ const getGroup = asyncHandler(async (request, result) => {
 
 const searchGroups = asyncHandler(async (request, result) => {
     try {
-        const { name, courses, majors, maxResults } = request.body
+        const { name, description, courses, majors, maxResults } = request.body
 
         console.debug(`\n\nSearching for groups with name: ${name}, courses: ${courses}, majors: ${majors}`)
 
         // search for groups with the given parameters
         const groups = await Group.find({
             name: { $regex: name, $options: 'i' },
+            description: { $regex: description, $options: 'i' },
             courses: { $in: courses },
             majors: { $in: majors },
         }).limit(maxResults)

--- a/backend/controllers/groupController.js
+++ b/backend/controllers/groupController.js
@@ -137,17 +137,16 @@ const getGroup = asyncHandler(async (request, result) => {
 
 const searchGroups = asyncHandler(async (request, result) => {
     try {
-        const { name, description, courses, majors, maxResults } = request.body
+        // const { name, description, courses, majors, maxResults } = request.body
+        const name = request.params.query
 
-        console.debug(`\n\nSearching for groups with name: ${name}, courses: ${courses}, majors: ${majors}`)
+        // console.debug(`\n\nSearching for groups with name: ${name}, courses: ${courses}, majors: ${majors}`)
+        console.debug(`\n\nSearching for groups with name: ${name}`)
 
         // search for groups with the given parameters
         const groups = await Group.find({
-            name: { $regex: name, $options: 'i' },
-            description: { $regex: description, $options: 'i' },
-            courses: { $in: courses },
-            majors: { $in: majors },
-        }).limit(maxResults)
+            name: { $regex: name, $options: 'i' }
+        })
 
         console.debug(`Found ${groups.length} groups`)
 

--- a/backend/routes/groupRoutes.js
+++ b/backend/routes/groupRoutes.js
@@ -22,6 +22,10 @@ const {
 router.route("/")
     .get(getAllGroups)
     .post(createGroup)
+
+// localhost:5678/api/group/search
+router.route("/search/:query")
+    .get(searchGroups)
     
 // localhost:5678/api/group/<groupID>
 router.route("/:groupID")
@@ -41,10 +45,6 @@ router.route("/:groupID/messages")
 router.route("/:groupID/meetings")
     .get(getMeetings)
     .put(createMeeting)
-
-// localhost:5678/api/group/search
-router.route("/search")
-    .get(searchGroups)
 
 // localhost:5678/api/group/join/<groupID>
 router.route("/join/:groupID")

--- a/backend/routes/groupRoutes.js
+++ b/backend/routes/groupRoutes.js
@@ -4,6 +4,7 @@ const {
     createGroup,
     getAllGroups,
     getGroup,
+    searchGroups,
     updateGroup,
     deleteGroup,
     joinGroup,
@@ -40,6 +41,10 @@ router.route("/:groupID/messages")
 router.route("/:groupID/meetings")
     .get(getMeetings)
     .put(createMeeting)
+
+// localhost:5678/api/group/search
+router.route("/search")
+    .get(searchGroups)
 
 // localhost:5678/api/group/join/<groupID>
 router.route("/join/:groupID")


### PR DESCRIPTION
The code added allows users to call the api `api/group/search/<query>` to search for specific groups.

Currently, for the MVP, only the group name can be searched.

To input a space in the URL query, use the `%20` char sequence, so use something like `api/group/search/group%204` for searching for `group 4`.