### PR TITLE
Update port used by textregion when obtaining messages

### DIFF
--- a/frontend/src/components/TextRegion/TextRegion.jsx
+++ b/frontend/src/components/TextRegion/TextRegion.jsx
@@ -4,7 +4,7 @@ import { useAuthContext } from '../../context/AuthContext';
 import axios from 'axios';
 import { useNavigate } from 'react-router-dom'; // Import useNavigate for navigation
 
-let baseURL = `http://localhost:${process.env.EXPRESS_PORT || 3000}`
+let baseURL = `http://localhost:${process.env.EXPRESS_PORT || 6789}`
 
 
 


### PR DESCRIPTION
This is a temporary fix as I intend to replace the `baseURL` variables from something hardcoded to being determined in a `getApiUrl` function, though this is still a work in progress and may or may not make it to the final product.